### PR TITLE
++ defaults for DB r/w, # of threads, added seed

### DIFF
--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -214,10 +214,10 @@ const uint64_t P2P_DEFAULT_INVOKE_TIMEOUT                    = 60 * 2 * 1000; //
 const size_t   P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT          = 5000;          // 5 seconds
 const char     P2P_STAT_TRUSTED_PUB_KEY[]                    = "";
 
-const uint64_t DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE         = 256;
-const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE          = 10;
-const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES               = 100;
-const uint16_t DATABASE_DEFAULT_BACKGROUND_THREADS_COUNT     = 2;
+const uint64_t DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE         = 1024;          // 1 GB
+const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE          = 1024;          // 1 GB
+const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES               = 500;           // 500 files
+const uint16_t DATABASE_DEFAULT_BACKGROUND_THREADS_COUNT     = 10;            // 10 DB threads
 
 const char     LATEST_VERSION_URL[]                          = "https://github.com/derogold/derogold/releases";
 const std::string LICENSE_URL                                = "https://github.com/derogold/derogold/blob/master/LICENSE";
@@ -231,5 +231,6 @@ const char* const SEED_NODES[] = {
     "78.46.49.89:42069", // explorer.dego.gq
     "5.172.219.174:42069", //sniperviperman // Edited as requested by sniperviperman.
     "149.129.97.195:42069", // netmebtc
+    "91.239.237.54:42069", // Leo Cuvée
 };
 } // CryptoNote


### PR DESCRIPTION
1. Increased DB read & write buffers to 1024 MB, max open files to 500 and 10 DB threads. This is to allow nodes to cope with high volumes of transactions. Helps nodes to stay synced with the network, and / or ensures node to be able to resync as fast as possible. Tested with 66k+ transactions in the pool.

2. added seed node Leo Cuvée