### PR TITLE
Slow and steady can connect wallet to daemon - Avoid daemon from dropping connection

### DIFF
--- a/src/WalletService/WalletServiceConfiguration.h
+++ b/src/WalletService/WalletServiceConfiguration.h
@@ -50,7 +50,7 @@ namespace PaymentService
         int logLevel = Logging::INFO;
 
         /* Timeout for daemon connection in seconds */
-        int initTimeout = 10;
+        int initTimeout = 120;
 
         /* Should we disable RPC connection */
         bool legacySecurity = false;


### PR DESCRIPTION
- Max 2 min if daemon stuck over 2 min, still dropping