### PR TITLE
Adjust rocksdb params

### DIFF
--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -286,7 +286,7 @@ namespace CryptoNote
     const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE = 512; // 512 MB
     const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = -1; // maximize files
     const uint16_t DATABASE_DEFAULT_BACKGROUND_THREADS_COUNT = 8; // 8 DB IncreaseParallelism
-    const uint64_t DATABASE_MAX_BYTES_FOR_LEVEL_BASE = 4096; // 4096MB // Additional tweak testing
+    const uint64_t DATABASE_MAX_BYTES_FOR_LEVEL_BASE = 5120; // 5120MB // Additional tweak testing
 
     const char LATEST_VERSION_URL[] = "https://github.com/derogold/derogold/releases";
 

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -282,11 +282,11 @@ namespace CryptoNote
     const size_t P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT = 5000; // 5 seconds
     const char P2P_STAT_TRUSTED_PUB_KEY[] = "";
 
-    const uint64_t DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE = 256; // 256 MB
-    const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE = 512; // 512 MB
-    const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = -1; // maximize files
+    const uint64_t DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE = 1024; // 1024 MB
+    const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE = 1024; // 1024 MB
+    const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = 64; // 64 max. files
     const uint16_t DATABASE_DEFAULT_BACKGROUND_THREADS_COUNT = 8; // 8 DB IncreaseParallelism
-    const uint64_t DATABASE_MAX_BYTES_FOR_LEVEL_BASE = 5120; // 5120MB // Additional tweak testing
+    const uint64_t DATABASE_MAX_BYTES_FOR_LEVEL_BASE = 20 * DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE; // Additional tweak testing
 
     const char LATEST_VERSION_URL[] = "https://github.com/derogold/derogold/releases";
 

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -284,7 +284,7 @@ namespace CryptoNote
 
     const uint64_t DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE = 1024; // 1024 MB
     const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE = 1024; // 1024 MB
-    const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = 64; // 64 max. files
+    const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = 128; // 128 max. files. Highend server just use -1 for no limit
     const uint16_t DATABASE_DEFAULT_BACKGROUND_THREADS_COUNT = 8; // 8 DB IncreaseParallelism
     const uint64_t DATABASE_MAX_BYTES_FOR_LEVEL_BASE = 20 * DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE; // Additional tweak testing
 

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -282,11 +282,11 @@ namespace CryptoNote
     const size_t P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT = 5000; // 5 seconds
     const char P2P_STAT_TRUSTED_PUB_KEY[] = "";
 
-    const uint64_t DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE = 512; // 512 MB
-    const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE = 1024; // 1 GB
-    const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = 64; // maximize files
+    const uint64_t DATABASE_WRITE_BUFFER_MB_DEFAULT_SIZE = 256; // 256 MB
+    const uint64_t DATABASE_READ_BUFFER_MB_DEFAULT_SIZE = 512; // 512 MB
+    const uint32_t DATABASE_DEFAULT_MAX_OPEN_FILES = -1; // maximize files
     const uint16_t DATABASE_DEFAULT_BACKGROUND_THREADS_COUNT = 8; // 8 DB IncreaseParallelism
-    const uint64_t DATABASE_MAX_BYTES_FOR_LEVEL_BASE = 512; // 512MB // Additional tweak testing
+    const uint64_t DATABASE_MAX_BYTES_FOR_LEVEL_BASE = 4096; // 4096MB // Additional tweak testing
 
     const char LATEST_VERSION_URL[] = "https://github.com/derogold/derogold/releases";
 

--- a/src/cryptonotecore/RocksDBWrapper.cpp
+++ b/src/cryptonotecore/RocksDBWrapper.cpp
@@ -231,7 +231,7 @@ rocksdb::Options RocksDBWrapper::getDBOptions(const DataBaseConfig &config)
         // don't compress l0 & l1
         fOptions.compression_per_level[i] = (i < 2 ? rocksdb::kNoCompression : compressionLevel);
     }
-    // bottom most use lz4hc
+    // bottom most use kZSTD
     fOptions.bottommost_compression =
         config.getCompressionEnabled() ? rocksdb::kZSTD : rocksdb::kNoCompression;
 


### PR DESCRIPTION
**DEGO** is always special :) This setting shall reduce the number of **sst** files created by rocksdb and to reduce the number of open files for rocksdb.

User can still use high values.

**Some remarks:**
* `--db-read-buffer-size`, `--db-write-buffer-size` and `--db-max-bytes-for-level-base` shall be set only one time at the first time sync OR leave them with default.
* `--db-threads` and `--db-max-open-files` can be adjusted anytime DEGO is startup or leave with default value.
* If you customize the params above and has many **sst** opened, please increase `--db-max-open-files`