### PR TITLE
Fix optimization zedwallet / WalletGreen

### DIFF
--- a/src/cryptonotecore/Currency.cpp
+++ b/src/cryptonotecore/Currency.cpp
@@ -364,6 +364,11 @@ namespace CryptoNote
             return false;
         }
 
+        if (amount < CryptoNote::parameters::FUSION_TX_MAX_POOL_AMOUNT_DUST_V1)
+        {
+            return false;
+        }
+
         auto it = std::lower_bound(Constants::PRETTY_AMOUNTS.begin(), Constants::PRETTY_AMOUNTS.end(), amount);
         if (it == Constants::PRETTY_AMOUNTS.end() || amount != *it)
         {

--- a/src/wallet/WalletGreen.cpp
+++ b/src/wallet/WalletGreen.cpp
@@ -3954,6 +3954,16 @@ namespace CryptoNote
                 + m_currency.formatAmount(m_currency.defaultFusionDustThreshold(height)));
         }
 
+        if (threshold <= CryptoNote::parameters::FUSION_TX_MAX_POOL_AMOUNT_DUST_V1)
+        {
+            m_logger(ERROR, BRIGHT_RED) << "Fusion transaction threshold is too small. Threshold "
+                                        << m_currency.formatAmount(threshold) << ", minimum threshold "
+                                        << m_currency.formatAmount(CryptoNote::parameters::FUSION_TX_MAX_POOL_AMOUNT_DUST_V1 + 1);
+            throw std::runtime_error(
+                "Threshold must be greater than "
+                + m_currency.formatAmount(CryptoNote::parameters::FUSION_TX_MAX_POOL_AMOUNT_DUST_V1));
+        }
+
         if (m_walletsContainer.get<RandomAccessIndex>().size() == 0)
         {
             m_logger(ERROR, BRIGHT_RED) << "The container doesn't have any wallets";


### PR DESCRIPTION
This shall fix optimizing wallet using `zedwallet`. However, the optimization in tx pool will cap by the value set in `FUSION_TX_MAX_POOL_COUNT`.

Conducted two tests already. Will confirm one more time after all stages done. Thanks to @LeoStehlik for a wallet for me to test :)