### PR TITLE
Require transactions to generate a PoW before being accepted by the daemon

### DIFF
--- a/include/ITransaction.h
+++ b/include/ITransaction.h
@@ -133,6 +133,8 @@ namespace CryptoNote
 
         // signing
         virtual void signInputKey(size_t input, const TransactionTypes::InputKeyInfo &info, const KeyPair &ephKeys) = 0;
+
+        virtual void generateTxProofOfWork() = 0;
     };
 
     class ITransaction : public ITransactionReader, public ITransactionWriter

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,7 +160,7 @@ endif ()
 
 # Add the dependencies we need
 target_link_libraries(Common __filesystem)
-target_link_libraries(CryptoNoteCore Utilities Common Logging Crypto P2P Rpc Http Serialization System ${Boost_LIBRARIES})
+target_link_libraries(CryptoNoteCore Utilities Common Logging Crypto P2P Rpc Http Serialization System ${Boost_LIBRARIES} WalletBackend)
 target_link_libraries(cryptotest Crypto Common)
 target_link_libraries(Errors Crypto SubWallets Utilities)
 target_link_libraries(Logging Common)

--- a/src/config/Constants.h
+++ b/src/config/Constants.h
@@ -197,6 +197,8 @@ namespace Constants
     /* Indicates the following data is a merge mine depth+merkle root */
     const uint8_t TX_EXTRA_MERGE_MINING_IDENTIFIER = 0x03;
 
+    const uint8_t TX_EXTRA_TRANSACTION_POW_NONCE_IDENTIFIER = 0x04;
+
     /* Indicates the following data is arbitrary data in tx_extra */
     const uint8_t TX_EXTRA_ARBITRARY_DATA_IDENTIFIER = 0x7f;
 

--- a/src/config/CryptoNoteConfig.h
+++ b/src/config/CryptoNoteConfig.h
@@ -140,6 +140,11 @@ namespace CryptoNote
 
         const uint64_t MAX_EXTRA_SIZE_V3_HEIGHT = 1470000;
 
+        const uint64_t TRANSACTION_POW_HEIGHT = 2500000;
+
+        /* Higher difficulty = More PoW (and thus time) to generate a transaction. */
+        const uint64_t TRANSACTION_POW_DIFFICULTY = 10000;
+
         /* For new projects forked from this code base, the values immediately below
            should be changed to 0 to prevent issues with transaction processing
            and other possible unexpected behavior */

--- a/src/cryptonotecore/Transaction.cpp
+++ b/src/cryptonotecore/Transaction.cpp
@@ -7,6 +7,8 @@
 #include "TransactionApiExtra.h"
 #include "TransactionUtils.h"
 #include "common/CryptoNoteTools.h"
+#include <common/CheckDifficulty.h>
+#include <walletbackend/Transfer.h>
 
 #include <boost/optional.hpp>
 #include <config/CryptoNoteConfig.h>
@@ -116,6 +118,8 @@ namespace CryptoNote
 
         virtual void
             signInputKey(size_t input, const TransactionTypes::InputKeyInfo &info, const KeyPair &ephKeys) override;
+
+        virtual void generateTxProofOfWork() override;
 
       private:
         void invalidateHash();
@@ -367,6 +371,12 @@ namespace CryptoNote
     {
         checkIfSigning();
         transaction.extra.insert(transaction.extra.end(), extraData.begin(), extraData.end());
+    }
+
+    void TransactionImpl::generateTxProofOfWork()
+    {
+        checkIfSigning();
+        transaction.extra = SendTransaction::generateTransactionPoW(transaction, transaction.extra);
     }
 
     bool TransactionImpl::getExtraNonce(BinaryArray &nonce) const

--- a/src/cryptonotecore/TransactionValidationErrors.h
+++ b/src/cryptonotecore/TransactionValidationErrors.h
@@ -45,7 +45,8 @@ namespace CryptoNote
             OUTPUT_AMOUNT_TOO_LARGE,
             EXCESSIVE_OUTPUTS,
             WRONG_FEE,
-            SIZE_TOO_LARGE
+            SIZE_TOO_LARGE,
+            POW_INVALID
         };
 
         // custom category:
@@ -132,6 +133,8 @@ namespace CryptoNote
                         return "Transaction fee is below minimum fee and is not a fusion transaction";
                     case TransactionValidationError::SIZE_TOO_LARGE:
                         return "Transaction is too large (in bytes)";
+                    case TransactionValidationError::POW_INVALID:
+                        return "Transaction has a too weak proof of work";
                     default:
                         return "Unknown error";
                 }

--- a/src/cryptonotecore/ValidateTransaction.cpp
+++ b/src/cryptonotecore/ValidateTransaction.cpp
@@ -558,7 +558,17 @@ bool ValidateTransaction::validateTransactionPoW()
     
     Crypto::cn_turtle_lite_slow_hash_v2(data.data(), data.size(), hash);
 
-    return CryptoNote::check_hash(hash, CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY);
+    if (CryptoNote::check_hash(hash, CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY))
+    {
+        return true;
+    }
+
+    setTransactionValidationResult(
+        CryptoNote::error::TransactionValidationError::POW_INVALID,
+        "Transaction has a too weak proof of work"
+    );
+
+    return false;
 }
 
 bool ValidateTransaction::validateTransactionInputsExpensive()

--- a/src/cryptonotecore/ValidateTransaction.h
+++ b/src/cryptonotecore/ValidateTransaction.h
@@ -76,6 +76,8 @@ class ValidateTransaction
 
         bool validateTransactionMixin();
 
+        bool validateTransactionPoW();
+
         bool validateTransactionInputsExpensive();
 
         void setTransactionValidationResult(const std::error_code &error_code, const std::string &error_message = "");

--- a/src/utilities/ParseExtra.cpp
+++ b/src/utilities/ParseExtra.cpp
@@ -52,10 +52,10 @@ namespace Utilities
         bool seenMergedMiningTag = false;
         bool seenPowNonce = false;
 
-        for (auto it = extra.begin(); it <= extra.end(); it++)
+        for (auto it = extra.begin(); it < extra.end(); it++)
         {
             /* Nothing else to parse. */
-            if (seenPubKey && seenPaymentID && seenMergedMiningTag && seenExtraData)
+            if (seenPubKey && seenPaymentID && seenMergedMiningTag && seenExtraData && seenPowNonce)
             {
                 break;
             }

--- a/src/utilities/ParseExtra.cpp
+++ b/src/utilities/ParseExtra.cpp
@@ -35,6 +35,12 @@ namespace Utilities
         return parsed.extraData;
     }
 
+    uint64_t getTransactionPowNonceFromExtra(const std::vector<uint8_t> &extra)
+    {
+        const ParsedExtra parsed = parseExtra(extra);
+        return parsed.transactionPowNonce;
+    }
+
     ParsedExtra parseExtra(const std::vector<uint8_t> &extra)
     {
         ParsedExtra parsed {Constants::NULL_PUBLIC_KEY, std::string(), {0, Constants::NULL_HASH}};
@@ -44,6 +50,7 @@ namespace Utilities
         bool seenExtraData = false;
         bool seenPaymentID = false;
         bool seenMergedMiningTag = false;
+        bool seenPowNonce = false;
 
         for (auto it = extra.begin(); it <= extra.end(); it++)
         {
@@ -201,6 +208,25 @@ namespace Utilities
                     continue;
                 }
             }
+
+            if (c == Constants::TX_EXTRA_TRANSACTION_POW_NONCE_IDENTIFIER && elementsRemaining > 8 && !seenPowNonce)
+            {
+                uint8_t tmp[8];
+
+                std::copy(it + 1, it + 1 + 8, std::begin(tmp));
+
+                /* Copy 8 chars, beginning from the next char */
+                std::memcpy(&parsed.transactionPowNonce, tmp, 8); 
+
+                /* Advance past the nonce identifier */
+                it += 8;
+
+                seenPowNonce = true;
+
+                /* And continue parsing. */
+                continue;
+            }
+
         }
 
         return parsed;

--- a/src/utilities/ParseExtra.h
+++ b/src/utilities/ParseExtra.h
@@ -22,6 +22,7 @@ namespace Utilities
         std::string paymentID;
         MergedMiningTag mergedMiningTag;
         std::vector<uint8_t> extraData;
+        uint64_t transactionPowNonce = 0;
     };
 
     std::string getPaymentIDFromExtra(const std::vector<uint8_t> &extra);

--- a/src/wallet/WalletGreen.cpp
+++ b/src/wallet/WalletGreen.cpp
@@ -2707,6 +2707,8 @@ namespace CryptoNote
             tx->addInput(makeAccountKeys(*input.walletRecord), input.keyInfo, input.ephKeys);
         }
 
+        tx->generateTxProofOfWork();
+
         size_t i = 0;
         for (auto &input : keysInfo)
         {

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -339,8 +339,6 @@ namespace SendTransaction
             return {UNEXPECTED_FEE, Crypto::Hash()};
         }
 
-        return {SUCCESS, Crypto::Hash()};
-
         const auto [sendError, txHash] = relayTransaction(txResult.transaction, daemon);
 
         if (sendError)

--- a/src/walletbackend/Transfer.cpp
+++ b/src/walletbackend/Transfer.cpp
@@ -8,6 +8,7 @@
 
 #include <config/Constants.h>
 #include <config/WalletConfig.h>
+#include <common/CheckDifficulty.h>
 #include <common/Varint.h>
 #include <errors/ValidateParameters.h>
 #include <utilities/Addresses.h>
@@ -337,6 +338,8 @@ namespace SendTransaction
         {
             return {UNEXPECTED_FEE, Crypto::Hash()};
         }
+
+        return {SUCCESS, Crypto::Hash()};
 
         const auto [sendError, txHash] = relayTransaction(txResult.transaction, daemon);
 
@@ -1084,8 +1087,11 @@ namespace SendTransaction
             return result;
         }
 
-        /* Pubkey, payment ID */
-        setupTX.extra = extra;
+        /* Generate the transaction proof of work, this comes before the ring
+         * signature generation, as ring signatures take the transaction prefix
+         * hash. Generating it afterwards would change the hash, and thus invalidate
+         * the sigs. */
+        setupTX.extra = generateTransactionPoW(setupTX, extra);
 
         /* Fill in the transaction signatures */
         /* NOTE: Do not modify the transaction after this, or the ring signatures
@@ -1142,6 +1148,85 @@ namespace SendTransaction
         uint64_t actualFee = inputTotal - outputTotal;
 
         return expectedFee == actualFee;
+    }
+
+    void generateTransactionPowWorker(
+        std::vector<uint8_t> &finalExtra,
+        const int threadCount,
+        uint64_t nonce,
+        std::atomic<bool> &shouldStop,
+        CryptoNote::Transaction tx)
+    {
+        /* Make a thread local copy */
+        auto extra = finalExtra;
+
+        /* Get a pointer to the start of where we want to insert our nonce */
+        const auto noncePosition = &extra[extra.size() - 8];
+
+        while (true)
+        {
+            if (shouldStop)
+            {
+                return;
+            }
+
+            /* Copy in the nonce */
+            std::memcpy(noncePosition, &nonce, sizeof(nonce));
+
+            Crypto::Hash hash;
+
+            tx.extra = extra;
+
+            std::vector<uint8_t> data = toBinaryArray(static_cast<CryptoNote::TransactionPrefix>(tx));
+
+            Crypto::cn_turtle_lite_slow_hash_v2(data.data(), data.size(), hash);
+
+            if (CryptoNote::check_hash(hash, CryptoNote::parameters::TRANSACTION_POW_DIFFICULTY))
+            {
+                finalExtra = extra;
+                shouldStop = true;
+
+                return;
+            }
+
+            nonce += threadCount;
+        }
+    }
+
+    std::vector<uint8_t> generateTransactionPoW(
+        CryptoNote::Transaction tx,
+        std::vector<uint8_t> extra)
+    {
+        /* Add the nonce identifier */
+        extra.push_back(Constants::TX_EXTRA_TRANSACTION_POW_NONCE_IDENTIFIER);
+
+        /* Add extra room for the nonce */
+        extra.resize(extra.size() + 8);
+
+        std::vector<std::thread> threads;
+
+        const int threadCount = std::max(1u, std::thread::hardware_concurrency());
+
+        std::atomic<bool> shouldStop = false;
+
+        for (int i = 0; i < threadCount; i++)
+        {
+            threads.push_back(std::thread(
+                generateTransactionPowWorker,
+                std::ref(extra),
+                threadCount,
+                i,
+                std::ref(shouldStop),
+                tx
+            ));
+        }
+
+        for (auto &thread : threads)
+        {
+            thread.join();
+        }
+
+        return extra;
     }
 
 } // namespace SendTransaction

--- a/src/walletbackend/Transfer.h
+++ b/src/walletbackend/Transfer.h
@@ -135,6 +135,10 @@ namespace SendTransaction
     /* Verify fee is as expected */
     bool verifyTransactionFee(const uint64_t expectedFee, CryptoNote::Transaction tx);
 
+    std::vector<uint8_t> generateTransactionPoW(
+        CryptoNote::Transaction tx,
+        std::vector<uint8_t> extra);
+
     /* Template so we can do transaction, and transactionprefix */
     template<typename T> Crypto::Hash getTransactionHash(T tx)
     {


### PR DESCRIPTION
Testing on testnet, both zedwallet and zedwallet-beta can generate transactions that are accepted by the daemon. Disabling the PoW generation code results in the transactions being rejected by the daemon as expected.

I imagine you will want to adjust the difficulty and fork height, I just popped those in there to have something to play around with.