### PR TITLE
Fix a bug where providing an empty transaction hash will cause the rpc to crash.

### DIFF
--- a/src/cryptonotecore/Core.cpp
+++ b/src/cryptonotecore/Core.cpp
@@ -1047,6 +1047,11 @@ namespace CryptoNote
 
         std::vector<Crypto::Hash> leftTransactions = transactionHashes;
 
+        if (leftTransactions.empty())
+        {
+            return;
+        }
+
         // find in main chain
         do
         {
@@ -1056,11 +1061,6 @@ namespace CryptoNote
             leftTransactions = std::move(missedTransactions);
             segment = segment->getParent();
         } while (segment != nullptr && !leftTransactions.empty());
-
-        if (leftTransactions.empty())
-        {
-            return;
-        }
 
         // find in alternative chains
         for (size_t chain = 1; chain < chainsLeaves.size(); ++chain)

--- a/src/cryptonotecore/Core.cpp
+++ b/src/cryptonotecore/Core.cpp
@@ -1062,6 +1062,11 @@ namespace CryptoNote
             segment = segment->getParent();
         } while (segment != nullptr && !leftTransactions.empty());
 
+        if (leftTransactions.empty())
+        {
+            return;
+        }
+
         // find in alternative chains
         for (size_t chain = 1; chain < chainsLeaves.size(); ++chain)
         {


### PR DESCRIPTION
Apparently, if you provide an empty transaction hashes, rpc will fail because the check for empty is after running at least 1 transaction. Apart from the default transaction that comes with each block, if there are no other transaction this will fail.